### PR TITLE
Don't import PyGame if sound is disabled.

### DIFF
--- a/src/gameconfig.py
+++ b/src/gameconfig.py
@@ -97,7 +97,7 @@ VISION_FLAG = None # takes an image unlike the other two
 # [ VOLUME CONFIG VARIABLES ] -----------------------------------------
 # ---------------------------------------------------------------------
 
-SOUND = 'enabled' # 'enabled', 'disabled'
+SOUND = True
 
 VOLUME = {
     'MUSIC': 0.1,

--- a/src/sound/SoundPlayer.py
+++ b/src/sound/SoundPlayer.py
@@ -4,9 +4,9 @@ from random import randint
 class SoundPlayer:
     def __init__(self, sound_arg, **kwargs):
         if gameconfig.SOUND:
-            import pygame
-            self.pygame = pygame
-            self.pygame.mixer.init()
+            from pygame import mixer
+            self.mixer = mixer
+            self.mixer.init()
             init_loop = kwargs.get('loop', False)
             if type(sound_arg) is dict:
                 sound = sound_arg['name'] + str(randint(1, sound_arg['number']))
@@ -20,7 +20,7 @@ class SoundPlayer:
                 self.loop = -1
                 gameconfig.CURRENT_TRACK = self
             self.sound_path = 'data/sound/' + sound + '.wav'
-            self.sound = self.pygame.mixer.Sound(self.sound_path)
+            self.sound = self.mixer.Sound(self.sound_path)
             self.sound.set_volume(self.volume)
         else:
             # if sound is false use empty object as current track
@@ -43,6 +43,6 @@ class SoundPlayer:
         if hasattr(self, 'sound'):
             self.sound.fadeout(2000)
             self.sound_path = 'data/sound/' + new_track + '.wav'
-            self.sound = self.pygame.mixer.Sound(self.sound_path)
+            self.sound = self.mixer.Sound(self.sound_path)
             self.sound.set_volume(self.volume)
             self.play()

--- a/src/sound/SoundPlayer.py
+++ b/src/sound/SoundPlayer.py
@@ -1,42 +1,48 @@
-import pygame
 import gameconfig
 from random import randint
 
 class SoundPlayer:
     def __init__(self, sound_arg, **kwargs):
-        pygame.mixer.init()
-        init_loop = kwargs.get('loop', False)
-        if type(sound_arg) is dict:
-            sound = sound_arg['name'] + str(randint(1, sound_arg['number']))
+        if gameconfig.SOUND:
+            import pygame
+            self.pygame = pygame
+            self.pygame.mixer.init()
+            init_loop = kwargs.get('loop', False)
+            if type(sound_arg) is dict:
+                sound = sound_arg['name'] + str(randint(1, sound_arg['number']))
+            else:
+                sound = sound_arg
+            if init_loop is not True:
+                self.volume = gameconfig.VOLUME['SOUND_FX']
+                self.loop = 0
+            else:
+                self.volume = gameconfig.VOLUME['MUSIC']
+                self.loop = -1
+                gameconfig.CURRENT_TRACK = self
+            self.sound_path = 'data/sound/' + sound + '.wav'
+            self.sound = self.pygame.mixer.Sound(self.sound_path)
+            self.sound.set_volume(self.volume)
         else:
-            sound = sound_arg
-        if init_loop is not True:
-            self.volume = gameconfig.VOLUME['SOUND_FX']
-            self.loop = 0
-        else:
+            # if sound is false use empty object as current track
             gameconfig.CURRENT_TRACK = self
-            self.volume = gameconfig.VOLUME['MUSIC']
-            self.loop = -1
-        self.sound_path = 'data/sound/' + sound + '.wav'
-        self.sound = pygame.mixer.Sound(self.sound_path)
-        self.sound.set_volume(self.volume)
+
 
     def play(self):
-        if gameconfig.SOUND is 'enabled':
+        if hasattr(self, 'sound'):
             self.sound.play(loops = self.loop)
 
     def stop(self):
-        if gameconfig.SOUND is 'enabled':
+        if hasattr(self, 'sound'):
             self.sound.stop()
 
     def fadeout(self, time):
-        if gameconfig.SOUND is 'enabled':
+        if hasattr(self, 'sound'):
             self.sound.fadeout(time)
 
     def switch_track(self, new_track):
-        if gameconfig.SOUND is 'enabled':
+        if hasattr(self, 'sound'):
             self.sound.fadeout(2000)
             self.sound_path = 'data/sound/' + new_track + '.wav'
-            self.sound = pygame.mixer.Sound(self.sound_path)
+            self.sound = self.pygame.mixer.Sound(self.sound_path)
             self.sound.set_volume(self.volume)
             self.play()

--- a/src/terminal/cli.py
+++ b/src/terminal/cli.py
@@ -83,7 +83,6 @@ def cli_window(command=None, selector=None):
     bc = BlinkingCursor()
     bc.start()
 
-    gameconfig.CURRENT_TRACK.switch_track(gameconfig.BACKGROUND_MUSIC['terminal'])
     bgnd_color = libtcod.dark_azure
     fgnd_color = libtcod.light_sky
     if not command: command = prompt
@@ -95,6 +94,7 @@ def cli_window(command=None, selector=None):
     libtcod.console_rect(window, 0, 0, width, height, True, libtcod.BKGND_SET)
     libtcod.console_print_ex(window, 1, 1, libtcod.BKGND_NONE, libtcod.LEFT, game_messages.TERMINAL_TITLE)
     text = [game_messages.TERMINAL_START_MESSAGE]
+    gameconfig.CURRENT_TRACK.switch_track(gameconfig.BACKGROUND_MUSIC['terminal'])
 
     while running:
         cli_refresh(text, command) #update screen


### PR DESCRIPTION
In order to help isolate threading conflicts moving forward, this PR configures the SoundPlayer object to only import and initialize the pygame package if sound is set to `True`.
